### PR TITLE
One alexa client per lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,42 +117,6 @@ Then in your `settings.py`, change
 ALEXA_BROWSER_CLIENT_LIFECYCLE_CLASS = 'my_project.custom.CustomAudioLifecycle'
 ```
 
-### Device context ###
-
-Passing extra context to AVS is useful if you're running a custom AVS skill and need some data passed from the client to the AVS adapter, e.g, a smart home skill that controls the lights in the current room must know from which room the audio command came from:
-
-```py
-import alexa_browser_client
-
-
-class NamedAudioLifecycle(alexa_browser_client.AudioLifecycle):
-    def __init__(self, room_name, *args, **kwargs):
-        self.room_name = room_name
-        super().__init__(*args, **kwargs)
-
-    def get_context(self):
-        return {
-            'header': {
-                'namespace': 'MyCustomSkill',
-                'name': 'RoomState'
-            },
-            'payload': {
-                'name': self.room_name,
-            }
-        }
-
-    def send_command_to_avs(self, *args, **kwargs):
-        return super().send_command_to_avs(context=self.get_context())
-
-```
-
-Then in your `settings.py`, change
-`settings.AUDIO_LIFECYCLE_CLASS` to the new custom audio lifecycle:
-
-```py
-ALEXA_BROWSER_CLIENT_LIFECYCLE_CLASS = 'my_project.custom.NamedAudioLifecycle'
-```
-
 ## Unit test ##
 
 To run the unit tests, call the following commands:
@@ -160,6 +124,12 @@ To run the unit tests, call the following commands:
 ```sh
 pip install -r requirements-dev.txt
 ./scripts/tests.sh
+```
+
+To test a specific file, call the following command:
+
+```sh
+./scripts/tests.sh /path/to/test-file.py
 ```
 
 ## Other projects

--- a/alexa_browser_client/alexa_browser_client/consumers.py
+++ b/alexa_browser_client/alexa_browser_client/consumers.py
@@ -1,19 +1,11 @@
 from django.utils.module_loading import import_string
 
 from alexa_browser_client.config import settings
-from alexa_browser_client.alexa_browser_client.helpers import alexa_client
 
 
 state = {
     'audio_lifecycles': {},
-    'has_connected': False,
 }
-
-
-def conditional_connect():
-    if not state['has_connected']:
-        alexa_client.connect()
-        state['has_connected'] = True
 
 
 def ws_add(message):
@@ -26,7 +18,7 @@ def ws_add(message):
     audio_lifecycle = AudioLifecycle(reply_channel=reply_channel)
     state['audio_lifecycles'][reply_channel.name] = audio_lifecycle
     audio_lifecycle.push_alexa_status('CONNECTING')
-    conditional_connect()
+    audio_lifecycle.alexa_client.connect()
     audio_lifecycle.push_alexa_status('EXPECTING_WAKEWORD')
 
 

--- a/alexa_browser_client/alexa_browser_client/helpers.py
+++ b/alexa_browser_client/alexa_browser_client/helpers.py
@@ -7,23 +7,22 @@ import command_lifecycle
 from django.conf import settings
 
 
-alexa_client = AlexaVoiceServiceClient(
-    client_id=settings.ALEXA_BROWSER_CLIENT_AVS_CLIENT_ID,
-    secret=settings.ALEXA_BROWSER_CLIENT_AVS_CLIENT_SECRET,
-    refresh_token=settings.ALEXA_BROWSER_CLIENT_AVS_REFRESH_TOKEN,
-)
-
-
 class AudioLifecycle(command_lifecycle.BaseAudioLifecycle):
     audio_converter_class = command_lifecycle.helpers.WebAudioToWavConverter
+    alexa_client_class = AlexaVoiceServiceClient
 
     def __init__(self, reply_channel):
         self.reply_channel = reply_channel
+        self.alexa_client = self.alexa_client_class(
+            client_id=settings.ALEXA_BROWSER_CLIENT_AVS_CLIENT_ID,
+            secret=settings.ALEXA_BROWSER_CLIENT_AVS_CLIENT_SECRET,
+            refresh_token=settings.ALEXA_BROWSER_CLIENT_AVS_REFRESH_TOKEN,
+        )
         super().__init__()
 
     def extend_audio(self, *args, **kwargs):
         super().extend_audio(*args, **kwargs)
-        alexa_client.conditional_ping()
+        self.alexa_client.conditional_ping()
 
     def handle_command_started(self):
         self.push_alexa_status('EXPECTING_COMMAND')
@@ -36,7 +35,7 @@ class AudioLifecycle(command_lifecycle.BaseAudioLifecycle):
 
     def send_command_to_avs(self, context=None):
         audio_file = command_lifecycle.helpers.LifeCycleFileLike(self)
-        alexa_response_audio = alexa_client.send_audio_file(
+        alexa_response_audio = self.alexa_client.send_audio_file(
             audio_file=audio_file, context=context
         )
         if alexa_response_audio:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 flake8 --exclude=.venv,venv,snowboy,build &&
-pytest --ignore=venv --ignore=.venv --ignore=build --cov=./ --cov-config=.coveragerc
+pytest $1 --ignore=venv --ignore=.venv --ignore=build --cov=./ --cov-config=.coveragerc

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def get_requirements():
 
 setup(
     name='alexa_browser_client',
-    version='0.5.0',
+    version='0.6.0',
     url='https://github.com/richtier/alexa-browser-client',
     license='MIT',
     author='Richard Tier',

--- a/tests/alexa_browser_client/test_consumers.py
+++ b/tests/alexa_browser_client/test_consumers.py
@@ -7,13 +7,8 @@ from alexa_browser_client.alexa_browser_client import consumers, helpers
 
 @pytest.fixture(autouse=True)
 def mock_client_connect():
-    path = (
-        'alexa_browser_client.alexa_browser_client.consumers.'
-        'alexa_client.connect'
-    )
-    stub = patch(path)
-    stub.start()
-    yield stub
+    stub = patch('avs_client.AlexaVoiceServiceClient.connect')
+    yield stub.start()
     stub.stop()
 
 
@@ -39,12 +34,12 @@ def test_ws_add_creates_default_audio_lifecycle(ws_client):
     assert isinstance(get_lifecycle(), helpers.AudioLifecycle)
 
 
-def test_ws_add_calls_conditional_connect(ws_client):
+def test_ws_add_calls_connect(ws_client, mock_client_connect):
     ws_client.send_and_consume('websocket.connect', check_accept=False)
     ws_client.send_and_consume('websocket.connect', check_accept=False)
     ws_client.send_and_consume('websocket.connect', check_accept=False)
 
-    assert consumers.alexa_client.connect.call_count == 1
+    assert get_lifecycle().alexa_client.connect.call_count == 3
 
 
 def test_ws_add_creates_custom_audio_lifecycle(ws_client, settings):
@@ -57,7 +52,7 @@ def test_ws_add_creates_custom_audio_lifecycle(ws_client, settings):
     assert isinstance(get_lifecycle(), Mock)
 
 
-def test_ws_add_creates_accecpts_connection(ws_client):
+def test_ws_add_creates_accepts_connection(ws_client):
     ws_client.send_and_consume('websocket.connect', check_accept=False)
 
     assert ws_client.receive() == {'type': 'CONNECTING'}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,8 +43,7 @@ def mock_snowboy(request):
         'wakeword_library_import_path'
     )
     stub = patch(path, PropertyMock(return_value='unittest.mock.Mock'))
-    stub.start()
-    yield stub
+    yield stub.start()
     stub.stop()
 
 
@@ -58,11 +57,6 @@ def requests_mocker():
 
 @pytest.fixture(autouse=True)
 def mock_client_connect():
-    path = (
-        'alexa_browser_client.alexa_browser_client.helpers.alexa_client.'
-        'connect'
-    )
-    stub = patch(path)
-    stub.start()
-    yield stub
+    stub = patch('avs_client.AlexaVoiceServiceClient.connect')
+    yield stub.start()
     stub.stop()


### PR DESCRIPTION
To differentiate devices, each device must have a different `alexa_client`.